### PR TITLE
Pull request: django-wysiwyg

### DIFF
--- a/django_wysiwyg/templates/admin/change_form.html
+++ b/django_wysiwyg/templates/admin/change_form.html
@@ -1,0 +1,70 @@
+{% extends "admin/change_form.html" %}
+
+{% load wysiwyg %}
+
+{% block extrahead %}
+	
+	{{ block.super }}
+	
+	{% wysiwyg_setup %}
+	
+{% endblock %}
+
+{% block extrastyle %}
+	
+	{{ block.super }}
+	
+	<style type="text/css">
+		<!--
+			
+			{% comment %}
+				
+				The below CSS rules are here to fix admin layout issues using 
+				CKEditor v3.6.1, or YUI Editor, via Django 1.3.
+				
+				Note: "kama" is the skin name; you will need to change this if 
+				using a different skin.
+				
+				CSS tested with:
+				
+				Mac OSX v10.6.7
+				Chrome v12.0.742.100; Firefox v5.0; Safari v5.0.5; Opera v11.11
+				
+				Windows Vista
+				Chrome v11.11; Internet Explorer v9.0.8112.16421; 
+				Internet Explorer v8.0.6001.19019; Opera v11.11; Safari v5.0.5; 
+				Firefox v3.6.11; Flock v3.5.3.4641
+				
+				Windows XP
+				Internet Explorer v6.0.2900.5512...
+				
+			{% endcomment %}
+			
+			/* CKEditor: */
+			.cke_skin_kama {
+				/* Un-comment one line or the other: */
+				/*width: 85%; float: left; display: inline;*/
+				/*clear: left;*/
+			}
+			
+			/* YUI Editor: */
+			.yui-editor-container {
+				/* IBID: */
+				/*float: left; display: inline;*/
+				/*clear: left;*/
+			}
+			
+		-->
+	</style>
+	
+{% endblock %}
+
+{% block content %}
+	
+	{{ block.super }}
+	
+	{# Replace XXXXXXXX with field name: #}
+	{% wysiwyg_editor "id_XXXXXXXX" %}
+	{# ... add more here... #}
+	
+{% endblock %}


### PR DESCRIPTION
Added change_form.html to repo; Added a "extrastyle" block with (optional) CSS fixes for admin.

Your docs should now match the structure of repo/package (in other words, templates/admin/change_form.html now exists).

Within the change_form.html file, I added a new block with info about the styles... I did not think there was a need to modify the README.rst file... I figure most people will crack open the change_form file and read the comments in there.

Hopefully this meets your standards... Let me know if you want me to change something.

Btw, I really love your robust documentation! I have been using Markdown for my docs, but I think I may switch to ReStructuredText for my next project. :)

I hope that helps! Thanks again for sharing this code with the rest of us!!!

Cheers,
Micky
