### PR TITLE
STATIC_URL instead of MEDIA_URL

### DIFF
--- a/django_wysiwyg/templatetags/wysiwyg.py
+++ b/django_wysiwyg/templatetags/wysiwyg.py
@@ -11,7 +11,7 @@ register = template.Library()
 def get_settings():
     """Utility function to retrieve settings.py values with defaults"""
     return {
-        "DJANGO_WYSIWYG_MEDIA_URL": getattr(settings, "DJANGO_WYSIWYG_MEDIA_URL", urljoin(settings.MEDIA_URL, "ckeditor/")),
+        "DJANGO_WYSIWYG_MEDIA_URL": getattr(settings, "DJANGO_WYSIWYG_MEDIA_URL", urljoin(settings.STATIC_URL, "ckeditor/")),
         "DJANGO_WYSIWYG_FLAVOR":    getattr(settings, "DJANGO_WYSIWYG_FLAVOR", "yui"),
         }
 


### PR DESCRIPTION
Since this isn't user-supplied media, it should be held in the same location as other static media. This slight change makes the template tag use the correct location if it falls back due to not having a setting.
