### PR TITLE
Updated the docs to match the change to using STATIC_URL for CKEditor.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ forms/model issue (i.e. control).
 YUI is the default editor due to familiarity, accessiblity and the fact that
 it's possible to run with entirely off of Yahoo's CDN, avoiding the need to
 maintain any local resources. CKEditor can be used but will require you to
-install the CKEditor files in MEDIA_URL/ckeditor (see below).
+install the CKEditor files in STATIC_URL/ckeditor (see below).
 
 If you want to contribute to django-wysiwyg, please do so from the repository
 at http://github.com/pydanny/django-wysiwyg.
@@ -44,7 +44,7 @@ If you wish to use CKEditor set the flavor in `settings.py`::
     DJANGO_WYSIWYG_FLAVOR = "ckeditor"
 
 Please note that doing so requires you to either place the ckeditor
-distributables under `MEDIA_URL/ckeditor` or set `DJANGO_WYSIWYG_MEDIA_URL`
+distributables under `STATIC_URL/ckeditor` or set `DJANGO_WYSIWYG_MEDIA_URL`
 in `settings.py` to the appropriate location containing the ckeditor
 distribution.
 

--- a/django_wysiwyg/templates/django_wysiwyg/ckeditor/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/ckeditor/includes.html
@@ -1,6 +1,6 @@
 {% comment %}
     CKEditor requires you to have the resources referenced below installed
-    under your MEDIA_URL. You can download them from ckeditor.com.
+    under your STATIC_URL. You can download them from ckeditor.com.
 {% endcomment %}
 
 <script type="text/javascript" src="{{ DJANGO_WYSIWYG_MEDIA_URL }}ckeditor.js"></script>

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -14,7 +14,7 @@ Other settings::
 
     DJANGO_WYSIWYG_FLAVOR = 'yui'       # Default
     # DJANGO_WYSIWYG_FLAVOR = 'ckeditor'  # Requires you to also place the ckeditor files here:
-    # DJANGO_WYSIWYG_MEDIA_URL = "%s/ckeditor" % MEDIA_URL
+    # DJANGO_WYSIWYG_MEDIA_URL = "%s/ckeditor" % STATIC_URL
 
 The following editors are supported out of the box:
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ forms/model issue (i.e. control).
 YUI is the default editor due to familiarity, accessiblity and the fact that
 it's possible to run with entirely off of Yahoo's CDN, avoiding the need to
 maintain any local resources. CKEditor can be used but will require you to
-install the CKEditor files in MEDIA_URL/ckeditor (see below).
+install the CKEditor files in STATIC_URL/ckeditor (see below).
 
 If you want to contribute to django-wysiwyg, please do so from the repository
 at http://github.com/pydanny/django-wysiwyg.
@@ -49,7 +49,7 @@ If you wish to use CKEditor set the flavor in `settings.py`::
     DJANGO_WYSIWYG_FLAVOR = "ckeditor"
 
 Please note that doing so requires you to either place the ckeditor
-distributables under `MEDIA_URL/ckeditor` or set `DJANGO_WYSIWYG_MEDIA_URL`
+distributables under `STATIC_URL/ckeditor` or set `DJANGO_WYSIWYG_MEDIA_URL`
 in `settings.py` to the appropriate location containing the ckeditor
 distribution.
 

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -78,4 +78,6 @@ INSTALLED_APPS = (
 
 DJANGO_WYSIWYG_FLAVOR = 'yui'       # Default
 # DJANGO_WYSIWYG_FLAVOR = 'ckeditor'  # Requires you to also place the ckeditor files here:
+# NOTE: If you are using DJANGO 1.3, you will want to follow the docs and use
+# STATIC_URL instead of MEDIA_URL here.
 # DJANGO_WYSIWYG_MEDIA_URL = "%s/ckeditor" % MEDIA_URL


### PR DESCRIPTION
I was trying to get this to work earlier and realized that the code had changed, but not the docs. I didn't chance the example settings.py file because it's still in an older style, but I added a note re: this issue.
