### PR TITLE
Fixes to make sure all editors actually work

### DIFF
--- a/django_wysiwyg/templates/django_wysiwyg/ckeditor/editor_instance.html
+++ b/django_wysiwyg/templates/django_wysiwyg/ckeditor/editor_instance.html
@@ -5,7 +5,7 @@
 
 <script type="text/javascript">
     (function(){
-	    var config = {{ config|default:"{}" }};
+	    var config = {{ config|default:"null" }};
 
         django_wysiwyg.enable('{{ editor_name }}', '{{ field_id }}', config);
     })();

--- a/django_wysiwyg/templates/django_wysiwyg/ckeditor/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/ckeditor/includes.html
@@ -3,9 +3,10 @@
     You can download them from ckeditor.com, or include django-ckeditor in your project.
 {% endcomment %}
 {% load wysiwyg %}
-<script type="text/javascript" src="{% wysiwyg_static_url "ckeditor" "ckeditor/ckeditor/" DJANGO_WYSIWYG_MEDIA_URL %}ckeditor.js"></script>
+<script type="text/javascript" src="{% wysiwyg_static_url 'ckeditor' 'ckeditor/ckeditor/' DJANGO_WYSIWYG_MEDIA_URL %}ckeditor.js"></script>
 <script type="text/javascript">
-    var django_wysiwyg_editor_configs = [];   // allow custom settings per editor ID{% block django_wysiwyg_editor_config %}
+    // allow custom settings per editor ID:
+    var django_wysiwyg_editor_configs = [];{% block django_wysiwyg_editor_config %}
     var django_wysiwyg_editor_config = {};
   {% endblock %}
 

--- a/django_wysiwyg/templates/django_wysiwyg/redactor/editor_instance.html
+++ b/django_wysiwyg/templates/django_wysiwyg/redactor/editor_instance.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
-    jQuery.fn.ready(function() {
-        var config = {{ config }};
+    (function() {
+        var config = {{ config|default:"null" }};
 
         django_wysiwyg.enable('{{ editor_name }}', '{{ field_id }}', config);
-    });
+    })();
 </script>

--- a/django_wysiwyg/templates/django_wysiwyg/redactor/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/redactor/includes.html
@@ -7,7 +7,8 @@
 <link rel="stylesheet" type="text/css" href="{{ DJANGO_WYSIWYG_MEDIA_URL }}css/redactor.css"/>
 <script type="text/javascript" src="{{ DJANGO_WYSIWYG_MEDIA_URL }}redactor.min.js"></script>
 <script type="text/javascript">
-    var django_wysiwyg_editor_configs = [];   // allow custom settings per editor ID{% block django_wysiwyg_editor_config %}
+    // allow custom settings per editor ID:
+    var django_wysiwyg_editor_configs = [];{% block django_wysiwyg_editor_config %}
     var django_wysiwyg_editor_config = {};
 {% endblock %}
 

--- a/django_wysiwyg/templates/django_wysiwyg/redactor/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/redactor/includes.html
@@ -23,7 +23,9 @@
             }
 
             if( !this.editors[editor_name] ) {
-                this.editors[editor_name] = jQuery("#" + field_id).redactor(config);
+                jQuery.fn.ready(function(){
+                    django_wysiwyg.editors[editor_name] = jQuery("#" + field_id).redactor(config);
+                });
             }
         },
 

--- a/django_wysiwyg/templates/django_wysiwyg/tinymce/editor_instance.html
+++ b/django_wysiwyg/templates/django_wysiwyg/tinymce/editor_instance.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
     (function() {
-        var config = {{ config }};
+        var config = {{ config|default:"null" }};
 
         django_wysiwyg.enable('{{ editor_name }}', '{{ field_id }}', config);
     })();

--- a/django_wysiwyg/templates/django_wysiwyg/tinymce/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/tinymce/includes.html
@@ -3,9 +3,10 @@
     You can download them from tinymce.com, or include django-tinymce in your project.
 {% endcomment %}
 {% load wysiwyg %}
-<script type="text/javascript" src="{% wysiwyg_static_url "tinymce" "tiny_mce/" DJANGO_WYSIWYG_MEDIA_URL %}tiny_mce_src.js"></script>
+<script type="text/javascript" src="{% wysiwyg_static_url 'tinymce' 'tiny_mce/' DJANGO_WYSIWYG_MEDIA_URL %}tiny_mce_src.js"></script>
 <script type="text/javascript">
-    var django_wysiwyg_editor_configs = [];   // allow custom settings per editor ID{% block django_wysiwyg_editor_config %}
+    // allow custom settings per editor ID:
+    var django_wysiwyg_editor_configs = [];{% block django_wysiwyg_editor_config %}
     var django_wysiwyg_editor_config = {
         relative_urls: false,
         custom_undo_redo_levels: 10,

--- a/django_wysiwyg/templates/django_wysiwyg/tinymce/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/tinymce/includes.html
@@ -34,13 +34,13 @@
                 tinyMCE.extend(localconfig, config);
                 tinyMCE.extend(localconfig, {
                     mode: "exact",
-                    elements: field_id
+                    elements: field_id,
+                    setup: function(editor) {
+                        django_wysiwyg.editors[editor_name] = editor;
+                    }
                 });
 
-                tinymce.dom.Event.add(window, 'init', function(){
-                    tinyMCE.init(localconfig);
-                    django_wysiwyg.editors[editor_name] = tinyMCE.editors[field_id];
-                });
+                tinyMCE.init(localconfig);
             }
         },
 

--- a/django_wysiwyg/templates/django_wysiwyg/tinymce/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/tinymce/includes.html
@@ -28,13 +28,17 @@
                 if( !config ) {
                     config = django_wysiwyg_editor_configs[field_id] || django_wysiwyg_editor_config;
                 }
-                config = tinymce.extend(config, {
+
+                // Apply extra settings in local copy.
+                var localconfig = {};
+                tinyMCE.extend(localconfig, config);
+                tinyMCE.extend(localconfig, {
                     mode: "exact",
                     elements: field_id
                 });
 
                 tinymce.dom.Event.add(window, 'init', function(){
-                    tinyMCE.init(config);
+                    tinyMCE.init(localconfig);
                     django_wysiwyg.editors[editor_name] = tinyMCE.editors[field_id];
                 });
             }

--- a/django_wysiwyg/templates/django_wysiwyg/tinymce_advanced/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/tinymce_advanced/includes.html
@@ -4,7 +4,7 @@
     var django_wysiwyg_editor_config = {
         relative_urls: false,
         custom_undo_redo_levels: 10,
-        plugins: 'paste,autoresize',
+        plugins: 'paste,autoresize,inlinepopups',
         strict_loading_mode: true,  // for pre 3.4 releases
 
         width: '610px',
@@ -15,6 +15,7 @@
         theme_advanced_buttons1: 'bold,italic,underline,strikethrough,|,link,unlink,|,bullist,numlist,|,undo,redo,|,formatselect,|,removeformat,cleanup,code',
         theme_advanced_buttons2: 'outdent,indent,|,sub,sup,|,image,charmap,anchor,hr',
         theme_advanced_buttons3: '',
-        theme_advanced_blockformats: 'h1,h2,h3,p'
+        theme_advanced_blockformats: 'h1,h2,h3,p',
+        theme_advanced_resizing : true
     };
 {% endblock %}

--- a/django_wysiwyg/templates/django_wysiwyg/yui/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/yui/includes.html
@@ -15,7 +15,7 @@
 <!-- Combo-handled YUI CSS files: -->
 <link rel="stylesheet" type="text/css" href="http://yui.yahooapis.com/combo?2.9.0/build/assets/skins/sam/skin.css">
 <!-- Combo-handled YUI JS files: -->
-<script type="text/javascript" src="http://yui.yahooapis.com/combo?2.9.0/build/yahoo-dom-event/yahoo-dom-event.js&2.9.0/build/container/container_core-min.js&2.9.0/build/menu/menu-min.js&2.9.0/build/element/element-min.js&2.9.0/build/button/button-min.js&2.9.0/build/editor/editor-min.js"></script>
+<script type="text/javascript" src="http://yui.yahooapis.com/combo?2.9.0/build/yahoo-dom-event/yahoo-dom-event.js&amp;2.9.0/build/container/container_core-min.js&amp;2.9.0/build/menu/menu-min.js&amp;2.9.0/build/element/element-min.js&amp;2.9.0/build/button/button-min.js&amp;2.9.0/build/editor/editor-min.js"></script>
 
 <script type="text/javascript" charset="utf-8">
     "use strict";

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     author_email='pydanny@gmail.com',
     url='https://github.com/pydanny/django-wysiwyg',
     license='MIT',
-    packages=find_packages(exclude=('test_project',)),
+    packages=find_packages(exclude=('test_project*',)),
     include_package_data=True,
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "Topic :: Text Processing :: Fonts",
         "Topic :: Text Processing :: Markup :: HTML"
     ],
-    keywords='django,wysiwyg,redactor,ckeditor,',
+    keywords='django,wysiwyg,redactor,ckeditor,tinymce',
     author=django_wysiwyg.__author__,
     author_email='pydanny@gmail.com',
     url='https://github.com/pydanny/django-wysiwyg',

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -87,3 +87,27 @@ DJANGO_WYSIWYG_FLAVOR = 'yui'       # Default
 # NOTE: If you are using DJANGO 1.3, you will want to follow the docs and use
 # STATIC_URL instead of MEDIA_URL here.
 # DJANGO_WYSIWYG_MEDIA_URL = "%s/ckeditor" % MEDIA_URL
+
+
+# Support newer Django versions:
+import django
+if django.VERSION >= (1,3):
+    STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
+    STATIC_URL = '/static/'
+
+    ADMIN_MEDIA_PREFIX = '/static/admin/'
+
+    INSTALLED_APPS += (
+        "django.contrib.staticfiles",
+    )
+
+    DATABASES = {
+        'default': {
+            'ENGINE':   'django.db.backends.' + DATABASE_ENGINE,
+            'NAME':     DATABASE_NAME,
+            'USER':     DATABASE_USER,
+            'PASSWORD': DATABASE_PASSWORD,
+            'HOST':     DATABASE_HOST,
+            'PORT':     DATABASE_PORT,
+        },
+    }

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -111,3 +111,18 @@ if django.VERSION >= (1,3):
             'PORT':     DATABASE_PORT,
         },
     }
+
+
+# Auto configure resources for editor flavors:
+if 'tinymce' in DJANGO_WYSIWYG_FLAVOR:
+    print "NOTE: Adding 'tinymce' to INSTALLED_APPS"
+    INSTALLED_APPS += (
+        'tinymce',
+    )
+elif 'ckeditor' in DJANGO_WYSIWYG_FLAVOR:
+    print "NOTE: Adding 'ckeditor' to INSTALLED_APPS"
+    INSTALLED_APPS += (
+        'ckeditor',
+    )
+    CKEDITOR_UPLOAD_PATH = MEDIA_ROOT
+

--- a/test_project/templates/fun/admin/fancyplayground/change_form.html
+++ b/test_project/templates/fun/admin/fancyplayground/change_form.html
@@ -53,6 +53,10 @@
 				/*clear: left;*/
 			}
 
+			/* General layout fix: */
+			.form-row.field-body label {
+				display: none;
+			}
 		-->
 	</style>
 

--- a/test_project/templates/fun/admin/playground/change_form.html
+++ b/test_project/templates/fun/admin/playground/change_form.html
@@ -3,6 +3,8 @@
 {% load wysiwyg %}
 
 {% block extrahead %}
+	{# Added for testing with Redactor #}
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 
 	{{ block.super }}
 

--- a/test_project/templates/fun/admin/playground/change_form.html
+++ b/test_project/templates/fun/admin/playground/change_form.html
@@ -70,3 +70,31 @@
 	{# ... add more here... #}
 
 {% endblock %}
+
+{% block after_related_objects %}
+    <p>
+        Editor is <span id="loaded-status"></span>. Testing:
+    </p>
+    <ul>
+        <li><a href="javascript:toggleEditor();">enable/disable editor</a></li>
+    </ul>
+    <script type="text/javascript">
+        document.getElementById('loaded-status').innerHTML = django_wysiwyg.is_loaded() ? 'loaded': 'not loaded!!';
+
+        function toggleEditor() {
+            if(! django_wysiwyg.is_loaded()) {
+                alert("The editor <script> files are missing or didn't load.\nPlease check the installation instructions of django-wysiwyg");
+                return;
+            }
+
+            var hasEditor = django_wysiwyg.editors['id_body_editor'] != null;
+
+            if(hasEditor) {
+                django_wysiwyg.disable('id_body_editor');
+            }
+            else {
+                django_wysiwyg.enable('id_body_editor', 'id_body', null);
+            }
+        }
+    </script>
+{% endblock %}

--- a/test_project/templates/fun/admin/playground/change_form.html
+++ b/test_project/templates/fun/admin/playground/change_form.html
@@ -55,6 +55,10 @@
 				/*clear: left;*/
 			}
 
+			/* General layout fix: */
+			.form-row.field-body label {
+				float: none;
+			}
 		-->
 	</style>
 


### PR DESCRIPTION
Hi,

I've went through the `test_project` and fixed every issue I found with initializing/enabling and disabling editors. It turned out there were still some bugs:
- CKEditor/TinyMCE/Redactor worked with the JavaScript API, but didn't work with `{% wysiwyg_setup %}`.
- TinyMCE didn't disable properly

This should fix the remaining issues of #28

A few other minor issues are fixed too:
- `setup.py` didn't exclude the `test_project` properly.
- Enabled inline popups for TinyMCE
- Made the test project work with Django 1.4 too.

I'm looking forward to get this merged, and have a new release out! :)
