### PR TITLE
suggest fork of django-ckeditor in documentation?

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Please note that doing so requires you to make sure the CKEditor distributables 
 You can either:
 
 * place the ckeditor distributables under `STATIC_URL/ckeditor`
-* install django-ckeditor_ and include it in the ``INSTALLED_APPS``
+* install django-ckeditor (either `Shaun Sephton's official package`_ or an up-to-date fork, like the `one provided by Piotr Malinski`_) and include it in the ``INSTALLED_APPS``
 * set `DJANGO_WYSIWYG_MEDIA_URL` in `settings.py` to the appropriate location containing the ckeditor distribution.
 
 Using TinyMCE
@@ -182,5 +182,6 @@ equivalent mode) and should currently be considered experimental.
 .. _Redactor: http://redactorjs.com/
 .. _TinyMCE: http://www.tinymce.com/
 .. _YAHOO: http://developer.yahoo.com/yui/editor/
-.. _django-ckeditor: https://github.com/shaunsephton/django-ckeditor
+.. _Shaun Sephton's official package: https://github.com/shaunsephton/django-ckeditor
+.. _one provided by Piotr Malinski: https://github.com/riklaunim/django-ckeditor
 .. _django-tinymce: https://github.com/aljosa/django-tinymce

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,7 +30,7 @@ Media sources
 
 When you use one of the editors, you need to make sure that the editor distributables
 are also located in your project. By default *django-wysiwyg* looks for a `STATIC_URL/flavor` folder.
-You can also install django-ckeditor_ or django-tinymce_ to have the CKEditor_ and TinyMCE_ distributables respectively.
+You can also install django-ckeditor (either the `official package`_ or an `updated fork`_) or django-tinymce_ to have the CKEditor_ and TinyMCE_ distributables respectively.
 *django-wysiwyg* will automatically find their sources if they are mentioned in the ``INSTALLED_APPS``.
 
 It's also possible to add new editors, see :doc:`extending django-wysiwyg <extending>`
@@ -40,5 +40,6 @@ It's also possible to add new editors, see :doc:`extending django-wysiwyg <exten
 .. _Redactor: http://redactorjs.com/
 .. _TinyMCE: http://www.tinymce.com/
 .. _YAHOO: http://developer.yahoo.com/yui/editor/
-.. _django-ckeditor: https://github.com/shaunsephton/django-ckeditor
+.. _official package: https://github.com/shaunsephton/django-ckeditor
+.. _updated fork: https://github.com/riklaunim/django-ckeditor
 .. _django-tinymce: https://github.com/aljosa/django-tinymce


### PR DESCRIPTION
[The "Media Sources" section of the installation documentation](https://github.com/pydanny/django-wysiwyg/blob/master/docs/install.rst#media-sources) currently suggests installing [shaunsephton's django-ckeditor](https://github.com/shaunsephton/django-ckeditor). However, that library does not currently support Django 1.6 and seems currently unmaintained.

It might make sense for the documentation to suggest [riklaunim's fork](https://github.com/riklaunim/django-ckeditor) instead. It is [currently available on PyPi](https://pypi.python.org/pypi/django-ckeditor-updated) and requires approximate the same amount of configuration as the original django-ckeditor.
