### PR TITLE
Froala editor support for django-wysiwyg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 docs/_build/
 dist/
 *.egg-info/
+.DS_Store

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,7 @@ The following values are allowed for the ``DJANGO_WYSIWYG_FLAVOR`` setting:
 
 * *ckeditor*         - The CKEditor_, formally known as FCKEditor.
 * *redactor*         - The Redactor_ editor (requires a license).
+* *froala*           - The Froala_ editor (requires a license).
 * *tinymce*          - The TinyMCE_ editor, in simple mode.
 * *tinymce_advanced* - The TinyMCE_ editor with many more toolbar buttons.
 * *yui*              - The YAHOO_ editor (the default)>
@@ -180,6 +181,7 @@ equivalent mode) and should currently be considered experimental.
 
 .. _CKEditor: http://ckeditor.com/
 .. _Redactor: http://redactorjs.com/
+.. _Froala: http://editor.froala.com/
 .. _TinyMCE: http://www.tinymce.com/
 .. _YAHOO: http://developer.yahoo.com/yui/editor/
 .. _Shaun Sephton's official package: https://github.com/shaunsephton/django-ckeditor

--- a/django_wysiwyg/templates/django_wysiwyg/froala/editor_instance.html
+++ b/django_wysiwyg/templates/django_wysiwyg/froala/editor_instance.html
@@ -1,0 +1,7 @@
+<script type="text/javascript">
+    (function() {
+        var config = {{ config|default:"null" }};
+
+        django_wysiwyg.enable('{{ editor_name }}', '{{ field_id }}', config);
+    })();
+</script>

--- a/django_wysiwyg/templates/django_wysiwyg/froala/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/froala/includes.html
@@ -4,8 +4,13 @@
 {% endcomment %}
 
 {% load wysiwyg %}
+<!-- jquery is required for froala -->
+<script src="http://code.jquery.com/jquery-1.10.2.js"></script>
+
+<link rel="stylesheet" type="text/css" href="{{ DJANGO_WYSIWYG_MEDIA_URL }}css/font-awesome.min.css"/>
 <link rel="stylesheet" type="text/css" href="{{ DJANGO_WYSIWYG_MEDIA_URL }}css/froala_editor.min.css"/>
 <script type="text/javascript" src="{{ DJANGO_WYSIWYG_MEDIA_URL }}froala_editor.min.js"></script>
+
 <script type="text/javascript">
     // allow custom settings per editor ID:
     var django_wysiwyg_editor_configs = [];{% block django_wysiwyg_editor_config %}

--- a/django_wysiwyg/templates/django_wysiwyg/froala/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/froala/includes.html
@@ -1,0 +1,46 @@
+{% comment %}
+    froala requires you to have the resources referenced below installed under your STATIC_URL.
+    You can download them from http://editor.froala.com/download
+{% endcomment %}
+
+{% load wysiwyg %}
+<link rel="stylesheet" type="text/css" href="{{ DJANGO_WYSIWYG_MEDIA_URL }}css/froala_editor.min.css"/>
+<script type="text/javascript" src="{{ DJANGO_WYSIWYG_MEDIA_URL }}froala_editor.min.js"></script>
+<script type="text/javascript">
+    // allow custom settings per editor ID:
+    var django_wysiwyg_editor_configs = [];{% block django_wysiwyg_editor_config %}
+    var django_wysiwyg_editor_config = {};
+{% endblock %}
+
+    var django_wysiwyg =
+    {
+        editors: {},
+
+        enable: function django_wysiwyg_enable(editor_name, field_id, config)
+        {
+            if( !config ) {
+                config = django_wysiwyg_editor_configs[field_id] || django_wysiwyg_editor_config;
+            }
+
+            if( !this.editors[editor_name] ) {
+                jQuery.fn.ready(function(){
+                    django_wysiwyg.editors[editor_name] = jQuery("#" + field_id).editable(config);
+                });
+            }
+        },
+
+        disable: function django_wysiwyg_disable(editor_name)
+        {
+            var editor = this.editors[editor_name];
+            if( editor ) {
+                editor.destroyEditor();
+                this.editors[editor_name] = null;
+            }
+        },
+
+        is_loaded: function django_wysiwyg_is_loaded()
+        {
+            return window.jQuery != null && window.jQuery.fn.editable != null;
+        }
+    }
+</script>

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "Topic :: Text Processing :: Fonts",
         "Topic :: Text Processing :: Markup :: HTML"
     ],
-    keywords='django,wysiwyg,redactor,ckeditor,tinymce',
+    keywords='django,wysiwyg,redactor,ckeditor,tinymce,froala',
     author=find_variable('__author__', 'django_wysiwyg', '__init__.py'),
     author_email='pydanny@gmail.com',
     url='https://github.com/pydanny/django-wysiwyg',


### PR DESCRIPTION
- Basic integration of [Froala](http://editor.froala.com/) editor.
- Updated documentation with necessary changes.
