### PR TITLE
Update link to django-ckeditor repo again in docs.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Please note that doing so requires you to make sure the CKEditor distributables 
 You can either:
 
 * place the ckeditor distributables under `STATIC_URL/ckeditor`
-* install django-ckeditor (either `Shaun Sephton's official package`_ or an up-to-date fork, like the `one provided by Piotr Malinski`_) and include it in the ``INSTALLED_APPS``
+* install django-ckeditor_ and include it in the ``INSTALLED_APPS``
 * set `DJANGO_WYSIWYG_MEDIA_URL` in `settings.py` to the appropriate location containing the ckeditor distribution.
 
 Using TinyMCE
@@ -184,6 +184,5 @@ equivalent mode) and should currently be considered experimental.
 .. _Froala: http://editor.froala.com/
 .. _TinyMCE: http://www.tinymce.com/
 .. _YAHOO: http://developer.yahoo.com/yui/editor/
-.. _Shaun Sephton's official package: https://github.com/shaunsephton/django-ckeditor
-.. _one provided by Piotr Malinski: https://github.com/riklaunim/django-ckeditor
+.. _django-ckeditor: https://github.com/django-ckeditor/django-ckeditor
 .. _django-tinymce: https://github.com/aljosa/django-tinymce

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,7 +30,7 @@ Media sources
 
 When you use one of the editors, you need to make sure that the editor distributables
 are also located in your project. By default *django-wysiwyg* looks for a `STATIC_URL/flavor` folder.
-You can also install django-ckeditor (either the `official package`_ or an `updated fork`_) or django-tinymce_ to have the CKEditor_ and TinyMCE_ distributables respectively.
+You can also install django-ckeditor_ or django-tinymce_ to have the CKEditor_ and TinyMCE_ distributables respectively.
 *django-wysiwyg* will automatically find their sources if they are mentioned in the ``INSTALLED_APPS``.
 
 It's also possible to add new editors, see :doc:`extending django-wysiwyg <extending>`
@@ -40,6 +40,5 @@ It's also possible to add new editors, see :doc:`extending django-wysiwyg <exten
 .. _Redactor: http://redactorjs.com/
 .. _TinyMCE: http://www.tinymce.com/
 .. _YAHOO: http://developer.yahoo.com/yui/editor/
-.. _official package: https://github.com/shaunsephton/django-ckeditor
-.. _updated fork: https://github.com/riklaunim/django-ckeditor
+.. _django-ckeditor: https://github.com/django-ckeditor/django-ckeditor
 .. _django-tinymce: https://github.com/aljosa/django-tinymce


### PR DESCRIPTION
Reverts changes in e00c4e146020 and updates link to official
django-ckeditor repository in installation documentation. Piotr
Malinski's fork has been merged into the official repository, whose link
has also changed.