### PR TITLE
Use the new destroy method in Redactor 10

### DIFF
--- a/django_wysiwyg/templates/django_wysiwyg/redactor/includes.html
+++ b/django_wysiwyg/templates/django_wysiwyg/redactor/includes.html
@@ -33,7 +33,7 @@
         {
             var editor = this.editors[editor_name];
             if( editor ) {
-                editor.destroyEditor();
+                editor.redactor('core.destroy');
                 this.editors[editor_name] = null;
             }
         },


### PR DESCRIPTION
This fixes https://github.com/pydanny/django-wysiwyg/issues/51
See http://imperavi.com/redactor/docs/api/core/#api-destroy for the new destroy method in Redactor 10.
